### PR TITLE
Bug：x86_64 版本包含 arm64 架构的 better-sqlite3 模块

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -84,4 +84,4 @@ appImage:
   artifactName: ChatLab-${version}.${ext}
 
 # 是否在构建之前重新编译原生模块
-npmRebuild: false
+npmRebuild: true


### PR DESCRIPTION
从 npmRebuild: false 改为 npmRebuild: true
electron-builder 会在打包时为每个目标架构重新编译原生依赖模块