### PR TITLE
docs: fix broken documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Currently supported: **WhatsApp, LINE, WeChat, QQ, Discord, Instagram, and Teleg
 
 - [Download Guide](https://chatlab.fun/?type=download)
 - [Chat Record Export Guide](https://chatlab.fun/usage/how-to-export.html)
-- [Standardized Format Specification](https://chatlab.fun/usage/chatlab-format.html)
+- [Standardized Format Specification](https://chatlab.fun/standard/chatlab-format.html)
 - [Troubleshooting Guide](https://chatlab.fun/usage/troubleshooting.html)
 
 ## Preview

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -26,7 +26,7 @@ ChatLab 是一个专注于社交记录分析的本地化应用。通过 AI 智�
 
 - [下载 ChatLab 指南](https://chatlab.fun/cn/?type=download)
 - [导出聊天记录指南](https://chatlab.fun/cn/usage/how-to-export.html)
-- [标准化格式规范](https://chatlab.fun/cn/usage/chatlab-format.html)
+- [标准化格式规范](https://chatlab.fun/cn/standard/chatlab-format.html)
 - [故障排查指南](https://chatlab.fun/cn/usage/troubleshooting.html)
 
 ## 预览界面


### PR DESCRIPTION
   ## Summary
   Fix broken documentation URLs for "Standardized Format Specification" in both `README.md` and `README.zh-CN.md`.

   ## Changes
   - Updated `chatlab-format.html` path from `usage/` to `standard/` for the English README.
   - Updated `chatlab-format.html` path from `cn/usage/` to `cn/standard/` for the Chinese README.

   ## Verification
   - [x] English link: https://chatlab.fun/standard/chatlab-format.html (Verified)
   - [x] Chinese link: https://chatlab.fun/cn/standard/chatlab-format.html (Verified)
