### PR TITLE
fix(import): 改用哈希去重修复消息丢失的问题

### DIFF
--- a/electron/main/merger/index.ts
+++ b/electron/main/merger/index.ts
@@ -5,6 +5,7 @@
 
 import * as fs from 'fs'
 import * as path from 'path'
+import { createHash } from 'crypto'
 import { parseFileSync, detectFormat } from '../parser'
 import { importData } from '../database/core'
 import { TempDbReader } from './tempCache'
@@ -73,7 +74,18 @@ export async function parseFileInfo(filePath: string): Promise<FileParseInfo> {
  * 生成消息的唯一标识（用于去重和冲突检测）
  */
 function getMessageKey(msg: ParsedMessage): string {
-  return `${msg.timestamp}_${msg.senderPlatformId}_${(msg.content || '').length}`
+  const hash = createHash('sha256')
+  hash.update(String(msg.timestamp))
+  hash.update('\0')
+  hash.update(msg.senderPlatformId)
+  hash.update('\0')
+  // 这里和增量导入保持同一语义，避免两条链路对“重复消息”的定义不一致。
+  hash.update(msg.content === null ? 'null' : 'text')
+  hash.update('\0')
+  if (msg.content !== null) {
+    hash.update(msg.content)
+  }
+  return hash.digest('base64url')
 }
 
 function getParsedMessageDisplayName(msg: ParsedMessage): string {

--- a/electron/main/worker/import/tempDb.ts
+++ b/electron/main/worker/import/tempDb.ts
@@ -4,6 +4,7 @@
  */
 
 import Database from 'better-sqlite3'
+import { createHash } from 'crypto'
 import * as fs from 'fs'
 import * as path from 'path'
 
@@ -84,9 +85,20 @@ export function cleanupTempDatabase(dbPath: string): void {
 
 /**
  * 生成消息去重键
- * 使用 timestamp + senderPlatformId + contentLength 作为去重标识
+ * 使用固定长度哈希作为去重标识。
+ * 直接用 content.length 会误判等长不同内容，直接用原文又会让 Set 长期持有大文本。
  */
 export function generateMessageKey(timestamp: number, senderPlatformId: string, content: string | null): string {
-  const contentLength = content ? content.length : 0
-  return `${timestamp}_${senderPlatformId}_${contentLength}`
+  const hash = createHash('sha256')
+  hash.update(String(timestamp))
+  hash.update('\0')
+  hash.update(senderPlatformId)
+  hash.update('\0')
+  // 显式区分 null 和空字符串，避免两者被折叠成同一个 key。
+  hash.update(content === null ? 'null' : 'text')
+  hash.update('\0')
+  if (content !== null) {
+    hash.update(content)
+  }
+  return hash.digest('base64url')
 }


### PR DESCRIPTION

  ## 问题原因

  当前项目里面使用的是秒级时间戳，而在导入消息的时候，原有去重键由以下字段组成：
 `timestamp + senderPlatformId + content length`

  这会导致一个明显问题：
  同一发送者如果在同一秒内连续发送两条不同内容、但长度相同的消息，其中一条会被误判为重复消息并被丢弃

  ## 修改内容
  在以下的位置：
  - electron/main/worker/import/tempDb.ts
  - electron/main/merger/index.ts

  将去重键改为基于以下字段生成固定长度哈希：
  `timestamp + senderPlatformId + exact content`

  这样既保留了“内容精确参与去重”的语义，也避免把原始特别长的文本，直接作为 Set key 占用内存

  ## 预期

  - 修复同秒、同发送者、等长不同内容消息的误去重问题
  - 统一导入与合并的流程中，使用同一套去重的规则
  - 减少内存占用，使用过长的完整消息文本