### PR TITLE
feat(ai): add OrcaRouter as a built-in named provider

### DIFF
--- a/packages/core/src/ai/__tests__/thinking.test.ts
+++ b/packages/core/src/ai/__tests__/thinking.test.ts
@@ -78,6 +78,16 @@ describe('isReasoningModel', () => {
     assert.equal(isReasoningModel('xai', 'grok-4-fast'), true)
     assert.equal(isReasoningModel('xai', 'grok-build'), true)
   })
+
+  it('returns true for orcarouter reasoning models', () => {
+    assert.equal(isReasoningModel('orcarouter', 'openai/gpt-5.5'), true)
+    assert.equal(isReasoningModel('orcarouter', 'deepseek/deepseek-v4-pro'), true)
+    assert.equal(isReasoningModel('orcarouter', 'grok/grok-4.3'), true)
+  })
+
+  it('returns false for orcarouter/auto (auto-routed)', () => {
+    assert.equal(isReasoningModel('orcarouter', 'orcarouter/auto'), false)
+  })
 })
 
 describe('getSupportedThinkingLevels', () => {
@@ -190,6 +200,27 @@ describe('getSupportedThinkingLevels', () => {
       'high',
     ])
   })
+
+  it('returns full range with default for orcarouter/openai/gpt-5.5', () => {
+    assert.deepEqual(getSupportedThinkingLevels('orcarouter', 'openai/gpt-5.5'), [
+      'default',
+      'off',
+      'minimal',
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+    ])
+  })
+
+  it('returns default+off+high+xhigh for orcarouter/deepseek/deepseek-v4-pro', () => {
+    assert.deepEqual(getSupportedThinkingLevels('orcarouter', 'deepseek/deepseek-v4-pro'), [
+      'default',
+      'off',
+      'high',
+      'xhigh',
+    ])
+  })
 })
 
 describe('getThinkingCompat', () => {
@@ -271,5 +302,21 @@ describe('getThinkingCompat', () => {
 
     const compat2 = getThinkingCompat('minimax', 'minimax-m2')
     assert.equal(compat2.thinkingFormat, 'deepseek')
+  })
+
+  it('returns supportsReasoningEffort + xhigh for orcarouter/openai/gpt-5.5', () => {
+    const compat = getThinkingCompat('orcarouter', 'openai/gpt-5.5')
+    assert.equal(compat.supportsReasoningEffort, true)
+    assert.equal(compat.thinkingLevelMap?.xhigh, 'xhigh')
+  })
+
+  it('returns thinkingFormat:deepseek for orcarouter/deepseek/deepseek-v4-pro', () => {
+    const compat = getThinkingCompat('orcarouter', 'deepseek/deepseek-v4-pro')
+    assert.equal(compat.thinkingFormat, 'deepseek')
+    assert.equal(compat.thinkingLevelMap?.xhigh, 'max')
+  })
+
+  it('returns {} for orcarouter/auto', () => {
+    assert.deepEqual(getThinkingCompat('orcarouter', 'orcarouter/auto'), {})
   })
 })

--- a/packages/core/src/ai/model-catalog.ts
+++ b/packages/core/src/ai/model-catalog.ts
@@ -768,6 +768,91 @@ const OPENROUTER_MODELS: ModelDefinition[] = [
   }),
 ]
 
+// ==================== OrcaRouter ====================
+
+const ORCAROUTER_MODELS: ModelDefinition[] = [
+  builtin({
+    id: 'orcarouter/auto',
+    providerId: 'orcarouter',
+    name: 'Auto',
+    description: 'OrcaRouter adaptive auto router (routes per request)',
+    contextWindow: 128000,
+    capabilities: ['chat', 'reasoning', 'function_calling'],
+    recommendedFor: ['chat'],
+    status: 'stable',
+  }),
+  builtin({
+    id: 'openai/gpt-5.5',
+    providerId: 'orcarouter',
+    name: 'GPT-5.5',
+    description: 'OpenAI GPT-5.5 via OrcaRouter',
+    contextWindow: 1000000,
+    capabilities: ['chat', 'reasoning', 'vision', 'function_calling'],
+    recommendedFor: ['chat'],
+    status: 'stable',
+  }),
+  builtin({
+    id: 'google/gemini-3.5-flash',
+    providerId: 'orcarouter',
+    name: 'Gemini 3.5 Flash',
+    description: 'Google Gemini 3.5 Flash via OrcaRouter',
+    contextWindow: 1048576,
+    capabilities: ['chat', 'reasoning', 'vision', 'function_calling'],
+    recommendedFor: ['chat'],
+    status: 'stable',
+  }),
+  builtin({
+    id: 'anthropic/claude-opus-4.8',
+    providerId: 'orcarouter',
+    name: 'Claude Opus 4.8',
+    description: 'Anthropic Claude Opus 4.8 via OrcaRouter',
+    contextWindow: 1000000,
+    capabilities: ['chat', 'reasoning', 'function_calling'],
+    recommendedFor: ['chat'],
+    status: 'stable',
+  }),
+  builtin({
+    id: 'grok/grok-4.3',
+    providerId: 'orcarouter',
+    name: 'Grok 4.3',
+    description: 'xAI Grok 4.3 via OrcaRouter',
+    contextWindow: 1000000,
+    capabilities: ['chat', 'reasoning', 'function_calling'],
+    recommendedFor: ['chat'],
+    status: 'stable',
+  }),
+  builtin({
+    id: 'deepseek/deepseek-v4-pro',
+    providerId: 'orcarouter',
+    name: 'DeepSeek V4 Pro',
+    description: 'DeepSeek V4 Pro via OrcaRouter',
+    contextWindow: 1048576,
+    capabilities: ['chat', 'reasoning', 'function_calling'],
+    recommendedFor: ['chat'],
+    status: 'stable',
+  }),
+  builtin({
+    id: 'minimax/minimax-m2.7',
+    providerId: 'orcarouter',
+    name: 'MiniMax M2.7',
+    description: 'MiniMax M2.7 via OrcaRouter',
+    contextWindow: 204800,
+    capabilities: ['chat', 'reasoning', 'function_calling'],
+    recommendedFor: ['chat'],
+    status: 'stable',
+  }),
+  builtin({
+    id: 'qwen/qwen3.7-max',
+    providerId: 'orcarouter',
+    name: 'Qwen 3.7 Max',
+    description: 'Alibaba Qwen 3.7 Max via OrcaRouter',
+    contextWindow: 1000000,
+    capabilities: ['chat', 'reasoning', 'function_calling'],
+    recommendedFor: ['chat'],
+    status: 'stable',
+  }),
+]
+
 // ==================== xAI ====================
 
 const XAI_MODELS: ModelDefinition[] = [
@@ -882,6 +967,7 @@ export const BUILTIN_MODELS: ModelDefinition[] = [
   ...SILICONFLOW_MODELS,
   ...GROQ_MODELS,
   ...OPENROUTER_MODELS,
+  ...ORCAROUTER_MODELS,
   ...XAI_MODELS,
   ...MINIMAX_MODELS,
 ]

--- a/packages/core/src/ai/provider-registry.ts
+++ b/packages/core/src/ai/provider-registry.ts
@@ -220,6 +220,29 @@ const OPENROUTER: ProviderDefinition = {
   modelIds: ['deepseek/deepseek-v4-pro', 'google/gemini-2.5-flash-preview', 'mistralai/mistral-7b-instruct:free'],
 }
 
+const ORCAROUTER: ProviderDefinition = {
+  id: 'orcarouter',
+  name: 'OrcaRouter',
+  kind: 'aggregator',
+  website: 'https://www.orcarouter.ai',
+  consoleUrl: 'https://www.orcarouter.ai',
+  defaultBaseUrl: 'https://api.orcarouter.ai/v1',
+  authMode: 'api-key',
+  supportsCustomModels: true,
+  builtin: true,
+  enabledByDefault: true,
+  modelIds: [
+    'orcarouter/auto',
+    'openai/gpt-5.5',
+    'google/gemini-3.5-flash',
+    'anthropic/claude-opus-4.8',
+    'grok/grok-4.3',
+    'deepseek/deepseek-v4-pro',
+    'minimax/minimax-m2.7',
+    'qwen/qwen3.7-max',
+  ],
+}
+
 const XAI: ProviderDefinition = {
   id: 'xai',
   name: 'xAI',
@@ -274,6 +297,7 @@ export const BUILTIN_PROVIDERS: ProviderDefinition[] = [
   SILICONFLOW,
   GROQ,
   OPENROUTER,
+  ORCAROUTER,
   XAI,
   MINIMAX,
   OPENAI_COMPATIBLE,

--- a/packages/core/src/ai/thinking.ts
+++ b/packages/core/src/ai/thinking.ts
@@ -191,6 +191,22 @@ function classifyThinkingType(provider: string, modelId: string): ThinkingType {
     return 'none'
   }
 
+  // ── OrcaRouter: classify by inner model id (ids carry a channel/namespace prefix,
+  //    e.g. openai/gpt-5.5, deepseek/deepseek-v4-pro; orcarouter/auto is the auto router) ──
+  if (prov === 'orcarouter') {
+    const inner = id.replace(/^orcarouter\//, '')
+    if (inner === 'auto') return 'none'
+    if (/gpt-5\.[2-9]|gpt-5\.[1-9]\d/.test(inner)) return 'gpt5_2plus'
+    if (/gpt-5\.1/.test(inner)) return 'gpt5_1'
+    if (/gpt-5/.test(inner)) return 'gpt5'
+    if (/deepseek.*(v[4-9]|r\d)/i.test(inner)) return 'deepseek_v4'
+    if (/deepseek[_-]?(chat|v3)/i.test(inner)) return 'deepseek_hybrid'
+    if (/\bgrok-(?:3-mini|4|4-fast|build)\b/i.test(inner)) return 'grok'
+    if (/\bkimi-k(?:2-thinking|2\.[5-9]|[3-9])/i.test(inner)) return 'kimi'
+    if (REASONING_FALLBACK_REGEX.test(inner)) return 'default'
+    return 'none'
+  }
+
   // ── Models using thinking:{type:'disabled'/'enabled'} format (same as DeepSeek) ──
   if (/\bmimo-v2/i.test(id)) return 'deepseek_hybrid'
   if (/\bminimax-m[123]/i.test(id)) return 'deepseek_hybrid'

--- a/src/i18n/locales/en-US/providers.json
+++ b/src/i18n/locales/en-US/providers.json
@@ -29,6 +29,9 @@
   "openrouter": {
     "name": "OpenRouter"
   },
+  "orcarouter": {
+    "name": "OrcaRouter"
+  },
   "xai": {
     "name": "xAI"
   },

--- a/src/i18n/locales/ja-JP/providers.json
+++ b/src/i18n/locales/ja-JP/providers.json
@@ -29,6 +29,9 @@
   "openrouter": {
     "name": "OpenRouter"
   },
+  "orcarouter": {
+    "name": "OrcaRouter"
+  },
   "xai": {
     "name": "xAI"
   },

--- a/src/i18n/locales/zh-CN/providers.json
+++ b/src/i18n/locales/zh-CN/providers.json
@@ -29,6 +29,9 @@
   "openrouter": {
     "name": "OpenRouter"
   },
+  "orcarouter": {
+    "name": "OrcaRouter"
+  },
   "xai": {
     "name": "xAI"
   },

--- a/src/i18n/locales/zh-TW/providers.json
+++ b/src/i18n/locales/zh-TW/providers.json
@@ -29,6 +29,9 @@
   "openrouter": {
     "name": "OpenRouter"
   },
+  "orcarouter": {
+    "name": "OrcaRouter"
+  },
   "xai": {
     "name": "xAI"
   },


### PR DESCRIPTION
## Overview

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class, named LLM provider in ChatLab, mirroring the existing OpenRouter entry end to end. OrcaRouter is an OpenAI-compatible model routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and others behind a single endpoint and API key, using namespaced model IDs such as `openai/gpt-5.5` and `orcarouter/auto`. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The provider is wired exactly like OpenRouter: an aggregator entry in the provider registry with base URL `https://api.orcarouter.ai/v1` and api-key auth, eight built-in models covering the `orcarouter/auto` router plus the flagship channel models, and per-model reasoning classification so the existing thinking-level selector works for each model family.

### Files changed

- `packages/core/src/ai/provider-registry.ts` — new `ORCAROUTER` `ProviderDefinition` (kind `aggregator`, base URL `https://api.orcarouter.ai/v1`, api-key auth, custom models supported) registered in `BUILTIN_PROVIDERS`.
- `packages/core/src/ai/model-catalog.ts` — new `ORCAROUTER_MODELS` builtin catalog: `orcarouter/auto`, `openai/gpt-5.5`, `google/gemini-3.5-flash`, `anthropic/claude-opus-4.8`, `grok/grok-4.3`, `deepseek/deepseek-v4-pro`, `minimax/minimax-m2.7`, `qwen/qwen3.7-max` (context windows taken from the OrcaRouter pricing API).
- `packages/core/src/ai/thinking.ts` — classify OrcaRouter models by their inner channel id (e.g. `openai/gpt-5.5`, `deepseek/deepseek-v4-pro`) so reasoning_effort / thinking-level wiring matches each model family; `orcarouter/auto` stays non-reasoning.
- `src/i18n/locales/{en-US,ja-JP,zh-CN,zh-TW}/providers.json` — OrcaRouter display name in all four locales.
- `packages/core/src/ai/__tests__/thinking.test.ts` — new cases covering OrcaRouter reasoning classification and compat maps.

### Verification

- `thinking.test.ts` suite: 54/54 passing, including the new OrcaRouter cases.
- Strict TypeScript typecheck of the touched AI modules: clean.
- Live L3 checks against `https://api.orcarouter.ai/v1/chat/completions` with the documented namespaced model IDs all returned content: `orcarouter/auto`, `openai/gpt-5.5`, `google/gemini-3.5-flash`, `deepseek/deepseek-v4-pro`, `anthropic/claude-opus-4.8`.

I'm an engineer on the OrcaRouter team.
